### PR TITLE
Fix leg equip floor bug

### DIFF
--- a/js/levels.js
+++ b/js/levels.js
@@ -43,7 +43,7 @@ export const levelData = {
         nests: [
             {
                 id: 'nest_1',
-                x: 150, y: 550, // Near the start
+                x: 1200, y: 550, // Further down the pipe
                 width: 120, // Approx 3x player base width
                 height: 30, // Approx 1x player base height
                 hasEggs: false,

--- a/js/player.js
+++ b/js/player.js
@@ -75,8 +75,12 @@ export default class Player {
             console.log("Can only shed exoskeleton at a nest.");
             return;
         }
+        const oldLegHeight = this.getLegHeight();
         // Use Object.assign to copy properties from staged to equipped
         Object.assign(this.equipped, this.stagedEquipment);
+        const newLegHeight = this.getLegHeight();
+        this.y -= (newLegHeight - oldLegHeight);
+        this.vy = 0;
         console.log("Exoskeleton shed. Equipment updated.");
     }
     


### PR DESCRIPTION
## Summary
- adjust player position when equipping or removing legs
- move the nest further down the level

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cd0d0f6888328a36fd328fcaaf03d