### PR TITLE
Improve skink interactions and health display

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -52,13 +52,19 @@ export class LittleBrownSkink extends Enemy {
 
         this.mouthOpen = false;
         this.mouthTimer = 0;
+        this.stunTimer = 0;
 
-        this.headWidth = height;      // large green head
-        this.headHeight = height * 0.9;
+        // Larger head for more cartoonish look
+        this.headWidth = height * 1.5;
+        this.headHeight = height * 1.3;
 
         const mouthWidth = this.headWidth * 0.4;
         const mouthHeight = this.headHeight * 0.6;
         this.mouth = { x: 0, y: 0, width: mouthWidth, height: mouthHeight };
+    }
+
+    stun(duration) {
+        this.stunTimer = duration;
     }
 
     attack(player) {
@@ -72,14 +78,18 @@ export class LittleBrownSkink extends Enemy {
     }
 
     update(room, player) {
-        // Basic chasing behaviour
-        if (player.x + player.width / 2 < this.x + this.width / 2) {
-            this.direction = -1;
+        if (this.stunTimer > 0) {
+            this.stunTimer--;
+            this.vx = 0;
         } else {
-            this.direction = 1;
+            // Basic chasing behaviour
+            if (player.x + player.width / 2 < this.x + this.width / 2) {
+                this.direction = -1;
+            } else {
+                this.direction = 1;
+            }
+            this.vx = this.speed * this.direction;
         }
-
-        this.vx = this.speed * this.direction;
 
         super.update(room);
 

--- a/js/levels.js
+++ b/js/levels.js
@@ -15,10 +15,10 @@ export const levelData = {
         platforms: [
             { x: 0, y: 580, width: ROOM1_WIDTH, height: 20, color: '#7f8c8d' },
             { x: 0, y: 0, width: ROOM1_WIDTH, height: 20, color: '#7f8c8d' },
-            // Small stone to test jumping
-            { x: 1080, y: 555, width: 40, height: 25, color: '#95a5a6' },
-            // Taller stone one player width away
-            { x: 1160, y: 530, width: 40, height: 50, color: '#95a5a6' },
+            // Small stone to test jumping (scaled to 60% height)
+            { x: 1080, y: 565, width: 40, height: 15, color: '#95a5a6' },
+            // Taller stone one player width away (scaled to 60% height)
+            { x: 1160, y: 550, width: 40, height: 30, color: '#95a5a6' },
         ],
         walls: [
             { x: ROOM1_WIDTH - 10, y: 0, width: 10, height: CANVAS_HEIGHT, color: '#27ae60', targetRoom: 1 },

--- a/js/player.js
+++ b/js/player.js
@@ -153,6 +153,16 @@ export default class Player {
                 context.restore();
             });
         }
+
+        if (!isStatic) {
+            const barWidth = this.width;
+            const barHeight = 5;
+            const healthRatio = this.health / this.maxHealth;
+            context.fillStyle = '#550000';
+            context.fillRect(drawX, drawY - barHeight - 2, barWidth, barHeight);
+            context.fillStyle = '#ff0000';
+            context.fillRect(drawX, drawY - barHeight - 2, barWidth * healthRatio, barHeight);
+        }
     }
 
     update(input, roomBoundaries) {

--- a/js/room.js
+++ b/js/room.js
@@ -106,6 +106,10 @@ export default class Room {
                     player.y = enemy.y - player.height;
                     player.vy = 0;
                     player.onGround = true;
+                    if (enemy.stun) enemy.stun(30);
+                } else if (player.vy < 0 && player.y - player.vy >= enemy.y + enemy.height) {
+                    player.vy = 0;
+                    player.y = enemy.y + enemy.height;
                 } else if (player.x < enemy.x) {
                     player.x = enemy.x - player.width;
                 } else {


### PR DESCRIPTION
## Summary
- shrink stone heights to 60% so they're easier to jump over
- enlarge skink head and implement stun when jumped on
- ensure player collision pushes from all sides and stuns skinks when stomped
- add a health bar above the player

## Testing
- `node --check js/enemy.js`
- `node --check js/room.js`
- `node --check js/player.js`
- `node --check js/levels.js`


------
https://chatgpt.com/codex/tasks/task_e_688d2af19b8883288886e735951c07b4