### PR TITLE
Refine skink behavior and player collisions

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -40,7 +40,7 @@ export class Enemy {
 export class LittleBrownSkink extends Enemy {
     constructor(x, y) {
         // Enemy size relative to the unevolved player
-        const width = 40 * 3;        // 3x the player width
+        const width = 40 * 2.5;      // Slightly shorter than before
         const height = 20 * 0.5;     // Half the player height
 
         super(x, y - height, width, height, '#ff69b4');
@@ -52,19 +52,26 @@ export class LittleBrownSkink extends Enemy {
 
         this.mouthOpen = false;
         this.mouthTimer = 0;
+        this.stunTimer = 0;
 
-        this.headWidth = height;      // large green head
-        this.headHeight = height * 0.9;
+        // Larger head for more cartoonish look
+        this.headWidth = height * 1.5;
+        this.headHeight = height * 1.3;
 
         const mouthWidth = this.headWidth * 0.4;
         const mouthHeight = this.headHeight * 0.6;
         this.mouth = { x: 0, y: 0, width: mouthWidth, height: mouthHeight };
     }
 
+    stun(duration) {
+        this.stunTimer = duration;
+    }
+
     attack(player) {
         const range = this.width;
         const dx = (player.x + player.width / 2) - (this.x + this.width / 2);
-        if (Math.abs(dx) < range && Math.abs(player.y - this.y) < this.height) {
+        const dy = player.y - this.y;
+        if (Math.abs(dx) < range && Math.abs(dy) < this.height * 2) {
             this.mouthOpen = true;
             this.mouthTimer = 20;
             this.hasDealtDamage = false;
@@ -72,14 +79,18 @@ export class LittleBrownSkink extends Enemy {
     }
 
     update(room, player) {
-        // Basic chasing behaviour
-        if (player.x + player.width / 2 < this.x + this.width / 2) {
-            this.direction = -1;
+        if (this.stunTimer > 0) {
+            this.stunTimer--;
+            this.vx = 0;
         } else {
-            this.direction = 1;
+            // Basic chasing behaviour
+            if (player.x + player.width / 2 < this.x + this.width / 2) {
+                this.direction = -1;
+            } else {
+                this.direction = 1;
+            }
+            this.vx = this.speed * this.direction;
         }
-
-        this.vx = this.speed * this.direction;
 
         super.update(room);
 
@@ -168,8 +179,12 @@ export class LittleBrownSkink extends Enemy {
         ctx.fillRect(headX, this.y + this.height * 0.1, this.headWidth, this.headHeight);
 
         if (this.mouthOpen) {
+            const phase = this.mouthTimer / 10 - 1; // 1 to -1 over timer
+            const openRatio = 1 - Math.abs(phase); // 0 -> 1 -> 0
+            const currentHeight = this.mouth.height * openRatio;
+            const mouthY = this.mouth.y + (this.mouth.height - currentHeight) / 2;
             ctx.fillStyle = '#ff9acb';
-            ctx.fillRect(this.mouth.x, this.mouth.y, this.mouth.width, this.mouth.height);
+            ctx.fillRect(this.mouth.x, mouthY, this.mouth.width, currentHeight);
         }
     }
 }

--- a/js/levels.js
+++ b/js/levels.js
@@ -15,10 +15,10 @@ export const levelData = {
         platforms: [
             { x: 0, y: 580, width: ROOM1_WIDTH, height: 20, color: '#7f8c8d' },
             { x: 0, y: 0, width: ROOM1_WIDTH, height: 20, color: '#7f8c8d' },
-            // Small stone to test jumping
-            { x: 1080, y: 555, width: 40, height: 25, color: '#95a5a6' },
-            // Taller stone one player width away
-            { x: 1160, y: 530, width: 40, height: 50, color: '#95a5a6' },
+            // Small stone to test jumping (scaled to 60% height)
+            { x: 1080, y: 565, width: 40, height: 15, color: '#95a5a6' },
+            // Taller stone one player width away (scaled to 60% height)
+            { x: 1160, y: 550, width: 40, height: 30, color: '#95a5a6' },
         ],
         walls: [
             { x: ROOM1_WIDTH - 10, y: 0, width: 10, height: CANVAS_HEIGHT, color: '#27ae60', targetRoom: 1 },

--- a/js/main.js
+++ b/js/main.js
@@ -96,6 +96,15 @@ function gameLoop() {
         drawInteractionPrompt(ctx, player, currentRoom);
         ctx.restore();
 
+        // --- UI Overlay ---
+        const barWidth = 100;
+        const barHeight = 10;
+        const healthRatio = player.health / player.maxHealth;
+        ctx.fillStyle = '#550000';
+        ctx.fillRect(10, 10, barWidth, barHeight);
+        ctx.fillStyle = '#ff0000';
+        ctx.fillRect(10, 10, barWidth * healthRatio, barHeight);
+
     } else if (gameState === 'INVENTORY') {
         ui.draw(ctx, canvas.width, canvas.height);
     }

--- a/js/player.js
+++ b/js/player.js
@@ -29,7 +29,7 @@ export default class Player {
         this.x = 0; this.y = 0;
         this.vx = 0; this.vy = 0;
         this.onGround = false;
-        this.friction = 0.9;
+        // friction is no longer needed as the player stops immediately
         this.wasJumpPressed = false;
         this.walkCycle = 0;
     }
@@ -153,6 +153,8 @@ export default class Player {
                 context.restore();
             });
         }
+
+        // Health bar is now drawn in the main loop's UI layer
     }
 
     update(input, roomBoundaries) {
@@ -162,7 +164,8 @@ export default class Player {
         } else if (input.isActionPressed('left')) {
             this.vx = -currentSpeed;
         } else {
-            this.vx *= this.friction;
+            // Stop instantly when no movement keys are pressed
+            this.vx = 0;
         }
         this.x += this.vx;
 

--- a/js/room.js
+++ b/js/room.js
@@ -65,13 +65,20 @@ export default class Room {
 
             if (nest.hasEggs) {
                 if (!nest.eggs) {
-                    // Create a few eggs with varying sizes and phase offsets
+                    // Create a cluster of eggs spread across the nest
                     nest.eggs = [
-                        { dx: -20, dy: 0, r: 4, phase: 0 },
-                        { dx: -5, dy: -3, r: 5, phase: 1 },
-                        { dx: 12, dy: 0, r: 3, phase: 2 },
-                        { dx: 5, dy: -6, r: 4, phase: 3 },
-                        { dx: 20, dy: -2, r: 5, phase: 4 }
+                        { dx: -50, dy: -3, r: 4, phase: 0 },
+                        { dx: -40, dy: 2, r: 3, phase: 1 },
+                        { dx: -30, dy: -2, r: 4, phase: 2 },
+                        { dx: -20, dy: 0, r: 4, phase: 3 },
+                        { dx: -10, dy: -5, r: 5, phase: 4 },
+                        { dx: -5, dy: 3, r: 3, phase: 5 },
+                        { dx: 5, dy: -6, r: 4, phase: 6 },
+                        { dx: 10, dy: 2, r: 3, phase: 7 },
+                        { dx: 20, dy: -2, r: 5, phase: 8 },
+                        { dx: 30, dy: -4, r: 4, phase: 9 },
+                        { dx: 40, dy: 1, r: 3, phase: 10 },
+                        { dx: 50, dy: -3, r: 4, phase: 11 }
                     ];
                 }
                 const t = Date.now() / 500;
@@ -106,10 +113,16 @@ export default class Room {
                     player.y = enemy.y - player.height;
                     player.vy = 0;
                     player.onGround = true;
+                    if (enemy.stun) enemy.stun(30);
+                } else if (player.vy < 0 && player.y - player.vy >= enemy.y + enemy.height) {
+                    player.vy = 0;
+                    player.y = enemy.y + enemy.height;
                 } else if (player.x < enemy.x) {
                     player.x = enemy.x - player.width;
+                    player.vx = 0;
                 } else {
                     player.x = enemy.x + enemy.width;
+                    player.vx = 0;
                 }
             }
 
@@ -136,6 +149,8 @@ export default class Room {
             const totalPlayerHeight = player.height + player.getLegHeight();
             const playerBottom = player.y + totalPlayerHeight;
             const playerPrevBottom = player.y - player.vy + totalPlayerHeight;
+            const playerPrevRight = player.x - player.vx + player.width;
+            const playerPrevLeft = player.x - player.vx;
 
             if (
                 player.x < platform.x + platform.width &&
@@ -147,10 +162,15 @@ export default class Room {
                     player.y = platform.y - totalPlayerHeight;
                     player.vy = 0;
                     player.onGround = true;
-                }
-                if (player.vy < 0 && player.y > platform.y) {
+                } else if (player.vy < 0 && player.y >= platform.y + platform.height) {
                     player.vy = 0;
                     player.y = platform.y + platform.height;
+                } else if (player.vx > 0 && playerPrevRight <= platform.x) {
+                    player.x = platform.x - player.width;
+                    player.vx = 0;
+                } else if (player.vx < 0 && playerPrevLeft >= platform.x + platform.width) {
+                    player.x = platform.x + platform.width;
+                    player.vx = 0;
                 }
             }
         });


### PR DESCRIPTION
## Summary
- move player health bar to top-left screen overlay and stop movement sliding
- prevent passing through stones and skinks with expanded side collision checks
- shorten skink, widen attack detection, and animate mouth when biting
- add more eggs around nests for fuller appearance

## Testing
- `node --check js/player.js`
- `node --check js/main.js`
- `node --check js/room.js`
- `node --check js/enemy.js`


------
https://chatgpt.com/codex/tasks/task_e_688d2af19b8883288886e735951c07b4