### PR TITLE
Display player health and refine skink collisions

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -133,6 +133,7 @@ export class LittleBrownSkink extends Enemy {
 
         const headX = this.direction === 1 ? this.x + this.width : this.x - this.headWidth;
         const headY = this.y + this.height * 0.1;
+        this.head = { x: headX, y: headY, width: this.headWidth, height: this.headHeight };
         const headFront = this.direction === 1 ? headX + this.headWidth : headX;
         this.mouth.x = headFront - this.mouth.width / 2;
         this.mouth.y = headY + this.headHeight / 2 - this.mouth.height / 2;

--- a/js/main.js
+++ b/js/main.js
@@ -97,6 +97,15 @@ function gameLoop() {
         ctx.restore();
 
         // --- UI Overlay ---
+        const uiBarWidth = 200;
+        const uiBarHeight = 20;
+        const uiRatio = player.health / player.maxHealth;
+        ctx.fillStyle = '#550000';
+        ctx.fillRect(20, 20, uiBarWidth, uiBarHeight);
+        ctx.fillStyle = '#ff0000';
+        ctx.fillRect(20, 20, uiBarWidth * uiRatio, uiBarHeight);
+        ctx.strokeStyle = '#000000';
+        ctx.strokeRect(20, 20, uiBarWidth, uiBarHeight);
     } else if (gameState === 'INVENTORY') {
         ui.draw(ctx, canvas.width, canvas.height);
     }

--- a/js/player.js
+++ b/js/player.js
@@ -154,15 +154,9 @@ export default class Player {
             });
         }
 
-        const barWidth = this.width;
-        const barHeight = 4;
-        const barX = drawX;
-        const barY = drawY - barHeight - 2;
-        const ratio = this.health / this.maxHealth;
-        context.fillStyle = '#550000';
-        context.fillRect(barX, barY, barWidth, barHeight);
-        context.fillStyle = '#ff0000';
-        context.fillRect(barX, barY, barWidth * ratio, barHeight);
+        // Player health is now drawn by the main UI rather than above the
+        // character sprite. Keeping drawing logic here would result in two
+        // health bars, so it has been removed.
     }
 
     update(input, roomBoundaries) {

--- a/js/room.js
+++ b/js/room.js
@@ -103,6 +103,24 @@ export default class Room {
         this.enemies.forEach(enemy => {
             enemy.update(this, player);
 
+            // Head collision damage
+            if (enemy.head &&
+                player.x < enemy.head.x + enemy.head.width &&
+                player.x + player.width > enemy.head.x &&
+                player.y < enemy.head.y + enemy.head.height &&
+                player.y + player.height > enemy.head.y) {
+                if (!enemy.hasDealtDamage) {
+                    player.health -= enemy.damage;
+                    enemy.hasDealtDamage = true;
+                }
+                if (player.x < enemy.head.x) {
+                    player.x = enemy.head.x - player.width;
+                } else {
+                    player.x = enemy.head.x + enemy.head.width;
+                }
+                player.vx = 0;
+            }
+
             if (enemy.mouthOpen && enemy.mouth && !enemy.hasDealtDamage) {
                 const m = enemy.mouth;
                 if (


### PR DESCRIPTION
## Summary
- Render a persistent health bar at the top-left corner of the screen
- Track the skink's head and apply damage on contact while allowing the player to stand on its body
- Remove the old per-sprite health bar to avoid duplicate UI

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/player.js js/main.js js/enemy.js js/room.js`


------
https://chatgpt.com/codex/tasks/task_e_68921b6935ac8328921d00d84753f9ef