### PR TITLE
Animate slug sprites and respawn from nests

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -82,7 +82,16 @@ function gameLoop() {
         player.update(input, { width: currentRoom.width, height: currentRoom.height });
         currentRoom.updateEnemies(player);
         const targetRoom = currentRoom.checkCollisions(player);
-        if (targetRoom !== null) {
+
+        if (player.health <= 0) {
+            if (player.lastNest) {
+                loadRoom(player.lastNest.roomId);
+                player.setPosition(player.lastNest.x, player.lastNest.y);
+            } else {
+                loadRoom(1);
+            }
+            player.health = player.maxHealth;
+        } else if (targetRoom !== null) {
             loadRoom(targetRoom);
         }
         camera.update(player, currentRoom);
@@ -124,6 +133,7 @@ function handleInteraction() {
             console.log("Interacting with nest.");
             player.health = player.maxHealth;
             nest.hasEggs = true;
+            player.lastNest = { roomId: currentRoom.id, x: player.x, y: player.y };
             // Set staged equipment to currently equipped gear when opening menu at nest
             Object.assign(player.stagedEquipment, player.equipped);
             gameState = 'INVENTORY';
@@ -191,6 +201,7 @@ function startGame() {
     resizeCanvas();
     gameState = 'PLAYING';
     loadRoom(1);
+    player.lastNest = { roomId: currentRoom.id, x: player.x, y: player.y };
     gameLoop();
 }
 

--- a/js/player.js
+++ b/js/player.js
@@ -6,16 +6,29 @@ export default class Player {
         this.gameHeight = gameHeight;
         
         this.inventory = [];
-        this.isEvolved = false; 
+        this.isEvolved = false;
 
         // --- NEW: Health & State ---
         this.maxHealth = 100;
         this.health = this.maxHealth;
         this.atNest = false; // Is the player currently at a nest?
+        this.lastNest = null; // Last visited nest for respawn
 
         // --- UPDATED: Equipment System ---
         this.equipped = { arms: null, legs: null };
         this.stagedEquipment = { arms: null, legs: null }; // Pending changes
+
+        // --- NEW: Unevolved slug sprites ---
+        this.sprites = {
+            unevolved: {
+                idle: new Image(),
+                move1: new Image(),
+                move2: new Image(),
+            },
+        };
+        this.sprites.unevolved.idle.src = 'Slug1.png';
+        this.sprites.unevolved.move1.src = 'Slug2.png';
+        this.sprites.unevolved.move2.src = 'Slug3.png';
 
         this.baseWidth = 40; this.baseHeight = 20;
         this.evolvedWidth = 25; this.evolvedHeight = 50;
@@ -124,9 +137,19 @@ export default class Player {
             });
         }
 
-        context.fillStyle = '#d35400';
-        context.fillRect(drawX, drawY, this.width, this.height);
-        if (this.isEvolved) {
+        if (!this.isEvolved) {
+            let sprite;
+            if (Math.abs(this.vx) > 0.1) {
+                sprite = Math.floor(currentWalkCycle) % 2 === 0
+                    ? this.sprites.unevolved.move1
+                    : this.sprites.unevolved.move2;
+            } else {
+                sprite = this.sprites.unevolved.idle;
+            }
+            context.drawImage(sprite, drawX, drawY, this.width, this.height);
+        } else {
+            context.fillStyle = '#d35400';
+            context.fillRect(drawX, drawY, this.width, this.height);
             context.fillStyle = '#2ecc71';
             context.fillRect(drawX, drawY, this.width, 7);
         }


### PR DESCRIPTION
## Summary
- Use Slug1/Slug2/Slug3 sprites for unevolved slug animation
- Track and restore last visited nest when the player dies

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689234b215a08328a33cb7496629c41f