### PR TITLE
Enlarge player sprite and improve skink collision

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -30,7 +30,8 @@ export default class Player {
         this.sprites.unevolved.move1.src = 'Slug2.png';
         this.sprites.unevolved.move2.src = 'Slug3.png';
 
-        this.baseWidth = 40; this.baseHeight = 20;
+        // Make the unevolved slug sprites larger on screen
+        this.baseWidth = 80; this.baseHeight = 40;
         this.evolvedWidth = 25; this.evolvedHeight = 50;
         this.baseSpeed = 3;
         this.baseJumpPower = 0;
@@ -140,9 +141,8 @@ export default class Player {
         if (!this.isEvolved) {
             let sprite;
             if (Math.abs(this.vx) > 0.1) {
-                sprite = Math.floor(currentWalkCycle) % 2 === 0
-                    ? this.sprites.unevolved.move1
-                    : this.sprites.unevolved.move2;
+                // Always use the third slug image when moving
+                sprite = this.sprites.unevolved.move2;
             } else {
                 sprite = this.sprites.unevolved.idle;
             }

--- a/js/room.js
+++ b/js/room.js
@@ -105,17 +105,21 @@ export default class Room {
 
             let isColliding = false;
 
-            // Head collision: purely damaging, no physical obstruction
+            // Head collision: stop the skink and damage the player continuously
             if (enemy.head &&
                 player.x < enemy.head.x + enemy.head.width &&
                 player.x + player.width > enemy.head.x &&
                 player.y < enemy.head.y + enemy.head.height &&
                 player.y + player.height > enemy.head.y) {
                 isColliding = true;
-                if (!enemy.hasDealtDamage) {
-                    player.health -= enemy.damage;
-                    enemy.hasDealtDamage = true;
+                // Position the skink so its head stays against the player
+                if (enemy.direction === 1) {
+                    enemy.x = player.x - enemy.headWidth - enemy.width;
+                } else {
+                    enemy.x = player.x + player.width + enemy.headWidth;
                 }
+                enemy.vx = 0;
+                player.health -= enemy.damage;
             }
 
             // Mouth collision when attacking


### PR DESCRIPTION
## Summary
- Double unevolved slug's sprite size and always use Slug3 while moving
- Stop skink movement on head contact and apply continuous damage when touching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68923a31a408832890b91bc05c17fb56