### PR TITLE
Fix enemy collision and respawn issues

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -90,6 +90,7 @@ function gameLoop() {
             } else {
                 loadRoom(1);
             }
+            currentRoom.checkCollisions(player);
             player.health = player.maxHealth;
         } else if (targetRoom !== null) {
             loadRoom(targetRoom);

--- a/js/room.js
+++ b/js/room.js
@@ -101,6 +101,8 @@ export default class Room {
 
     updateEnemies(player) {
         this.enemies.forEach(enemy => {
+            const prevX = enemy.x;
+            const prevY = enemy.y;
             enemy.update(this, player);
 
             let isColliding = false;
@@ -143,6 +145,8 @@ export default class Room {
             const playerPrevBottom = player.y - player.vy + totalPlayerHeight;
             const playerPrevRight = player.x - player.vx + player.width;
             const playerPrevLeft = player.x - player.vx;
+            const enemyPrevRight = prevX + enemy.width;
+            const enemyPrevLeft = prevX;
 
             if (
                 player.x < enemy.x + enemy.width &&
@@ -159,24 +163,34 @@ export default class Room {
                 } else if (player.vy < 0 && player.y >= enemy.y + enemy.height) {
                     player.vy = 0;
                     player.y = enemy.y + enemy.height;
-                } else if (player.vx > 0 && playerPrevRight <= enemy.x) {
+                } else if (playerPrevRight <= enemyPrevLeft && player.x + player.width > enemy.x) {
                     if (!enemy.hasDealtDamage) {
                         player.health -= enemy.damage;
                         enemy.hasDealtDamage = true;
                     }
                     enemy.mouthOpen = true;
                     enemy.mouthTimer = 20;
-                    player.x = enemy.x - player.width;
-                    player.vx = 0;
-                } else if (player.vx < 0 && playerPrevLeft >= enemy.x + enemy.width) {
+                    if (player.vx > 0) {
+                        player.x = enemy.x - player.width;
+                        player.vx = 0;
+                    } else {
+                        enemy.x = player.x + player.width;
+                        enemy.vx = 0;
+                    }
+                } else if (playerPrevLeft >= enemyPrevRight && player.x < enemy.x + enemy.width) {
                     if (!enemy.hasDealtDamage) {
                         player.health -= enemy.damage;
                         enemy.hasDealtDamage = true;
                     }
                     enemy.mouthOpen = true;
                     enemy.mouthTimer = 20;
-                    player.x = enemy.x + enemy.width;
-                    player.vx = 0;
+                    if (player.vx < 0) {
+                        player.x = enemy.x + enemy.width;
+                        player.vx = 0;
+                    } else {
+                        enemy.x = player.x - enemy.width;
+                        enemy.vx = 0;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- ensure respawned player snaps to room geometry
- handle enemy-initiated side collisions so enemies can't pass through player

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68925183f0e08328b85e46229f55162a