### PR TITLE
Prevent skinks from acting while asleep and extend room

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -109,29 +109,9 @@ export class LittleBrownSkink extends Enemy {
             this.sleepTimer--;
             if (this.sleepTimer === 0) this.sleeping = false;
             this.vx = 0;
+            this.mouthOpen = false;
             super.update(room);
-            // Bounce off room edges
-            if (this.x <= 0 || this.x + this.width >= room.width) {
-                this.direction *= -1;
-                this.x = Math.max(0, Math.min(this.x, room.width - this.width));
-            }
-            // Bounce off platforms from the sides
-            room.platforms.forEach(p => {
-                if (
-                    this.x < p.x + p.width &&
-                    this.x + this.width > p.x &&
-                    this.y < p.y + p.height &&
-                    this.y + this.height > p.y
-                ) {
-                    if (this.vx > 0 && this.x + this.width - this.vx <= p.x) {
-                        this.x = p.x - this.width;
-                        this.direction = -1;
-                    } else if (this.vx < 0 && this.x - this.vx >= p.x + p.width) {
-                        this.x = p.x + p.width;
-                        this.direction = 1;
-                    }
-                }
-            });
+            // No turning or attacking while asleep
             return;
         }
 

--- a/js/levels.js
+++ b/js/levels.js
@@ -2,7 +2,7 @@
 
 const CANVAS_WIDTH = 800;
 const CANVAS_HEIGHT = 600;
-const ROOM1_WIDTH = 2300;
+const ROOM1_WIDTH = 2600;
 
 export const levelData = {
     1: {
@@ -19,6 +19,9 @@ export const levelData = {
             { x: 1080, y: 565, width: 40, height: 15, color: '#95a5a6' },
             // Taller stone one player width away (scaled to 60% height)
             { x: 1160, y: 550, width: 40, height: 30, color: '#95a5a6' },
+            // Additional stones where the old wall used to be
+            { x: 1960, y: 565, width: 40, height: 15, color: '#95a5a6' },
+            { x: 2040, y: 550, width: 40, height: 30, color: '#95a5a6' },
         ],
         walls: [
             { x: ROOM1_WIDTH - 10, y: 0, width: 10, height: CANVAS_HEIGHT, color: '#27ae60', targetRoom: 1 },


### PR DESCRIPTION
## Summary
- Stop sleeping skinks from turning or attacking
- Extend room 1 and add new stone obstacles where an old wall stood

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689359a9707c8328a427603644f550ac