### PR TITLE
Add weight-based movement and item stat popups

### DIFF
--- a/js/levels.js
+++ b/js/levels.js
@@ -36,14 +36,14 @@ export const levelData = {
                 name: 'Broken Arms',
                 type: 'arms',
                 x: 600, y: 570, width: 30, height: 10, color: '#111',
-                stats: { Attack: 0, Defense: 0, Weight: 5 }
+                stats: { AttackPower: 1, AttackSpeed: 1, Weight: 5 }
             },
             {
                 id: 'ant_legs',
                 name: 'Broken Legs',
                 type: 'legs',
                 x: 850, y: 570, width: 30, height: 10, color: '#111',
-                stats: { Jump: 1, Speed: 1, Weight: 7 }
+                stats: { Speed: 1, JumpPower: 1, Weight: 5 }
             }
         ],
         // NEW: Array for nests

--- a/js/player.js
+++ b/js/player.js
@@ -35,7 +35,8 @@ export default class Player {
         this.evolvedWidth = 25; this.evolvedHeight = 50;
         this.baseSpeed = 3;
         this.baseJumpPower = 0;
-        this.baseWeight = 0.8;
+        this.baseWeight = 0.8; // Gravity constant
+        this.bodyWeightMg = 500; // Weight of the slug in mg
         const jumpHeight = this.evolvedHeight / 2;
         this.jumpVelocityUnit = -Math.sqrt(2 * this.baseWeight * jumpHeight);
         
@@ -97,15 +98,24 @@ export default class Player {
         this.vy = 0;
         console.log("Exoskeleton shed. Equipment updated.");
     }
-    
+
+    getTotalWeightMg() {
+        let total = this.bodyWeightMg;
+        if (this.equipped.arms) total += this.equipped.arms.stats.Weight;
+        if (this.equipped.legs) total += this.equipped.legs.stats.Weight;
+        return total;
+    }
+
     getCurrentSpeed() {
         const gearBonus = this.equipped.legs ? this.equipped.legs.stats.Speed : 0;
-        return this.baseSpeed + gearBonus;
+        const weightRatio = this.bodyWeightMg / this.getTotalWeightMg();
+        return (this.baseSpeed + gearBonus) * weightRatio;
     }
 
     getCurrentJumpPower() {
-        const gearBonus = this.equipped.legs ? this.equipped.legs.stats.Jump * this.jumpVelocityUnit : 0;
-        return this.baseJumpPower + gearBonus;
+        const gearBonus = this.equipped.legs ? this.equipped.legs.stats.JumpPower * this.jumpVelocityUnit : 0;
+        const weightRatio = this.bodyWeightMg / this.getTotalWeightMg();
+        return (this.baseJumpPower + gearBonus) * weightRatio;
     }
 
     collectItem(item) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -171,13 +171,16 @@ export class InventoryUI {
         const closePopupRect = { x: popupX + popupWidth - 25, y: popupY + 5, width: 20, height: 20 };
         ctx.font = '20px Arial';
         ctx.fillText('X', closePopupRect.x + 10, closePopupRect.y + 15);
-        
+
         if (this.player.isEvolved) {
+            this.drawItemIcon(ctx, this.popupItem, popupX + popupWidth / 2, popupY + 90, 60);
             ctx.font = '20px Georgia';
             ctx.textAlign = 'left';
-            let yPos = popupY + 90;
+            ctx.textBaseline = 'alphabetic';
+            let yPos = popupY + 150;
             for (const [stat, value] of Object.entries(this.popupItem.stats)) {
-                ctx.fillText(`${stat}: ${value}`, popupX + 30, yPos);
+                const displayValue = stat === 'Weight' ? `${value} mg` : value;
+                ctx.fillText(`${stat}: ${displayValue}`, popupX + 30, yPos);
                 yPos += 30;
             }
             const equipButtonRect = { x: popupX + 50, y: popupY + popupHeight - 70, width: 200, height: 40 };
@@ -185,7 +188,7 @@ export class InventoryUI {
             const buttonText = isStaged ? 'Unstage' : 'Stage for Shedding';
             ctx.fillStyle = isStaged ? '#e67e22' : '#3498db'; // Orange for unstage, Blue for stage
             ctx.fillRect(equipButtonRect.x, equipButtonRect.y, equipButtonRect.width, equipButtonRect.height);
-            
+
             ctx.fillStyle = 'white';
             ctx.font = '24px Georgia';
             ctx.textAlign = 'center';


### PR DESCRIPTION
## Summary
- Show item icon and detailed stats in inventory popups, including weight in mg
- Define ant arm/leg stats with 5 mg weight and attack/speed attributes
- Scale player speed and jump by total carried weight

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893fe82a520832898d5fa93ba4e7de0