### PR TITLE
Fix pause overlay hidden behind canvas

### DIFF
--- a/style.css
+++ b/style.css
@@ -22,6 +22,7 @@ html, body {
     left: 0;
     display: none; /* Hidden by default */
     background-color: #000;
+    z-index: 0;
 }
 
 /* Make the start screen also take up the entire container */
@@ -128,6 +129,7 @@ html, body {
     backdrop-filter: blur(5px);
     background: rgba(0,0,0,0.5);
     color: #e0e0e0;
+    z-index: 10;
 }
 
 #pause-menu button,


### PR DESCRIPTION
## Summary
- Ensure game canvas has a lower z-index than overlays
- Raise pause and settings menu overlay z-index so they display when the game is paused

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895e69429508328b1657173a533341c