### PR TITLE
Implement respawn tracking and save deletion UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,10 +15,17 @@
         </div>
         <div id="save-screen" class="hidden">
             <h2>Select Save Slot</h2>
-            <button class="save-slot" data-slot="0">Slot 1 - Empty</button>
-            <button class="save-slot" data-slot="1">Slot 2 - Empty</button>
-            <button class="save-slot" data-slot="2">Slot 3 - Empty</button>
+            <div class="save-row"><button class="save-slot" data-slot="0">Slot 1 - Empty</button><button class="delete-slot" data-slot="0">Delete Save</button></div>
+            <div class="save-row"><button class="save-slot" data-slot="1">Slot 2 - Empty</button><button class="delete-slot" data-slot="1">Delete Save</button></div>
+            <div class="save-row"><button class="save-slot" data-slot="2">Slot 3 - Empty</button><button class="delete-slot" data-slot="2">Delete Save</button></div>
             <button id="save-back-button">Back</button>
+        </div>
+        <div id="delete-confirm" class="hidden">
+            <div class="delete-dialog">
+                <p>Are you sure? This action cannot be undone.</p>
+                <button id="confirm-delete">Delete Save</button>
+                <button id="cancel-delete">Cancel</button>
+            </div>
         </div>
         <div id="pause-menu" class="hidden blur">
             <button id="resume-button">Resume</button>

--- a/js/enemy.js
+++ b/js/enemy.js
@@ -1,5 +1,5 @@
 export class Enemy {
-    constructor(x, y, width, height, color) {
+    constructor(x, y, width, height, color, id, respawnType = 'room') {
         this.x = x;
         this.y = y;
         this.width = width;
@@ -10,6 +10,8 @@ export class Enemy {
         this.onGround = false;
         this.hasDealtDamage = false;
 
+        this.id = id;
+        this.respawnType = respawnType;
     }
 
     update(room) {
@@ -38,12 +40,12 @@ export class Enemy {
 }
 
 export class LittleBrownSkink extends Enemy {
-    constructor(x, y) {
+    constructor(x, y, id, respawnType = 'room') {
         // Enemy size relative to the unevolved player
         const width = 40 * 2.5;      // Slightly shorter than before
         const height = 20 * 0.5;     // Half the player height
 
-        super(x, y, width, height, '#ff69b4');
+        super(x, y, width, height, '#ff69b4', id, respawnType);
         this.damage = 40;
 
         this.baseSpeed = 1.5;

--- a/js/levels.js
+++ b/js/levels.js
@@ -30,13 +30,13 @@ export const levelData = {
             { x: 0, y: 0, width: 10, height: CANVAS_HEIGHT, color: '#7f8c8d', targetRoom: null },
         ],
         powerups: [
-            { x: 1000, y: 570, width: 50, height: 10, color: '#2ecc71', type: 'evolution_power' }
+            { id: 'power_goop_1', x: 1000, y: 570, width: 50, height: 10, color: '#2ecc71', type: 'evolution_power', respawnType: 'never' }
         ],
         interactables: [
-            { ...items.arms.brokenArms, x: 600, y: 570 },
-            { ...items.legs.brokenLegs, x: 850, y: 570 },
+            { ...items.arms.brokenArms, uid: 'broken_arms_1', respawnType: 'never', x: 600, y: 570 },
+            { ...items.legs.brokenLegs, uid: 'broken_legs_1', respawnType: 'never', x: 850, y: 570 },
             // Sword near the first skink spawn
-            { ...items.swords.usedQtip, x: 1300, y: 560 }
+            { ...items.swords.usedQtip, uid: 'qtip_sword_1', respawnType: 'never', x: 1300, y: 560 }
         ],
         // NEW: Array for nests
         nests: [
@@ -50,8 +50,8 @@ export const levelData = {
             }
         ],
         enemies: [
-            { type: "little_brown_skink", x: 1300, y: 570 },
-            { type: "little_brown_skink", x: 1800, y: 570 }
+            { id: 'skink_1', type: "little_brown_skink", x: 1300, y: 570, respawnType: 'room' },
+            { id: 'skink_2', type: "little_brown_skink", x: 1800, y: 570, respawnType: 'room' }
         ],
     },
 };

--- a/js/room.js
+++ b/js/room.js
@@ -17,7 +17,7 @@ export default class Room {
         this.enemies = (roomData.enemies || []).map(e => {
             switch (e.type) {
                 case 'little_brown_skink':
-                    return new LittleBrownSkink(e.x, e.y);
+                    return new LittleBrownSkink(e.x, e.y, e.id, e.respawnType);
                 default:
                     return null;
             }
@@ -240,7 +240,7 @@ export default class Room {
         }
     }
 
-    checkCollisions(player) {
+    checkCollisions(player, respawnData, saveGame) {
         // --- Platform Collisions ---
         this.platforms.forEach(platform => {
             const totalPlayerHeight = player.height + player.getLegHeight();
@@ -284,7 +284,17 @@ export default class Room {
                 if (powerup.type === 'evolution_power') {
                     player.evolve();
                 }
+                if (respawnData) {
+                    if (powerup.respawnType === 'never') {
+                        if (!respawnData.permanent[this.id]) respawnData.permanent[this.id] = [];
+                        respawnData.permanent[this.id].push(powerup.id);
+                    } else if (powerup.respawnType === 'bench') {
+                        if (!respawnData.bench[this.id]) respawnData.bench[this.id] = [];
+                        respawnData.bench[this.id].push(powerup.id);
+                    }
+                }
                 this.powerups.splice(i, 1);
+                if (saveGame) saveGame();
             }
         }
 

--- a/style.css
+++ b/style.css
@@ -115,6 +115,52 @@ html, body {
     cursor: pointer;
 }
 
+.save-row {
+    display: flex;
+    gap: 10px;
+}
+
+.delete-slot {
+    border-color: #aa3333;
+}
+
+#delete-confirm {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    animation: pulse 1s infinite;
+    z-index: 20;
+}
+
+.delete-dialog {
+    text-align: center;
+}
+
+#confirm-delete {
+    background: red;
+    border: 2px solid #aa0000;
+    color: #fff;
+    padding: 10px 20px;
+    cursor: pointer;
+}
+
+#cancel-delete {
+    margin-left: 20px;
+    padding: 10px 20px;
+    cursor: pointer;
+}
+
+@keyframes pulse {
+    0% { background-color: rgba(255, 0, 0, 0.3); }
+    50% { background-color: rgba(255, 0, 0, 0.6); }
+    100% { background-color: rgba(255, 0, 0, 0.3); }
+}
+
 .rebind-header {
     display: flex;
     gap: 20px;


### PR DESCRIPTION
## Summary
- Track world objects with `respawnType` to control whether they return on room load, bench rest, or never
- Add save-slot deletion with confirmation dialog and pulsing warning screen
- Flip player sprite when running left/right

## Testing
- `node --check js/player.js`
- `node --check js/enemy.js`
- `node --check js/room.js`
- `node --check js/main.js`
- `node --check js/levels.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68995a00df748328b13d4a3510b48f45