### PR TITLE
Add armor slot, q-tip sprite, and skink post-hit behavior

### DIFF
--- a/Qtip.svg
+++ b/Qtip.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="60" height="10" viewBox="0 0 60 10">
+  <rect x="0" y="3" width="50" height="4" fill="#ffffff"/>
+  <rect x="50" y="2" width="10" height="6" fill="#ffff00"/>
+</svg>

--- a/js/enemy.js
+++ b/js/enemy.js
@@ -77,6 +77,10 @@ export class LittleBrownSkink extends Enemy {
         this.willSleep = false;
         this.sleeping = false;
         this.sleepTimer = 0;
+
+        // Post-hit behavior
+        this.afterHitState = null; // 'retreat' or 'charge'
+        this.afterHitTimer = 0;
     }
 
     stun(duration) {
@@ -104,6 +108,12 @@ export class LittleBrownSkink extends Enemy {
             this.mouthTimer = 20;
             this.hasDealtDamage = false;
         }
+    }
+
+    onDealDamage(player) {
+        this.afterHitState = 'retreat';
+        this.afterHitTimer = 30;
+        this.direction = player.x < this.x ? 1 : -1;
     }
 
     update(room, player) {
@@ -173,6 +183,32 @@ export class LittleBrownSkink extends Enemy {
                     }
                 }
             });
+            return;
+        }
+
+        if (this.afterHitState) {
+            if (this.afterHitState === 'retreat') {
+                this.vx = this.baseSpeed * 2 * this.direction;
+                this.afterHitTimer--;
+                if (this.afterHitTimer <= 0) {
+                    this.afterHitState = 'charge';
+                    this.afterHitTimer = 30;
+                    this.direction = player.x < this.x ? -1 : 1;
+                }
+            } else if (this.afterHitState === 'charge') {
+                this.vx = this.baseSpeed * 2.5 * this.direction;
+                this.afterHitTimer--;
+                if (this.afterHitTimer <= 0) {
+                    this.afterHitState = null;
+                }
+            }
+            this.mouthOpen = false;
+            super.update(room);
+            const headX = this.direction === 1 ? this.x + this.width : this.x - this.headWidth;
+            this.head = { x: headX, y: this.y + this.height * 0.1, width: this.headWidth, height: this.headHeight };
+            const headFront = this.direction === 1 ? headX + this.headWidth : headX;
+            this.mouth.x = headFront - this.mouth.width / 2;
+            this.mouth.y = this.y + this.height * 0.1 + this.headHeight / 2 - this.mouth.height / 2;
             return;
         }
 

--- a/js/items.js
+++ b/js/items.js
@@ -35,6 +35,7 @@ export const items = {
             height: 10,
             color: '#ffffff',
             tipColor: '#ffff00',
+            image: 'Qtip.svg',
             stats: { Weight: 28, Sharpness: 1 },
             description: 'You probably should not touch the yellow end.'
         }

--- a/js/main.js
+++ b/js/main.js
@@ -113,7 +113,7 @@ function loadSave(slot) {
     const slots = JSON.parse(localStorage.getItem('saveSlots') || '[]');
     return slots[slot] || {
         inventory: [],
-        equipped: { arms: null, legs: null, weapon: null, wings: null },
+        equipped: { arms: null, legs: null, weapon: null, wings: null, armor: null },
         isEvolved: false,
         stats: { items: 0, bosses: 0, money: 0 },
         lastNest: null,
@@ -130,7 +130,8 @@ function saveGame() {
             arms: player.equipped.arms ? player.equipped.arms.id : null,
             legs: player.equipped.legs ? player.equipped.legs.id : null,
             weapon: player.equipped.weapon ? player.equipped.weapon.id : null,
-            wings: player.equipped.wings ? player.equipped.wings.id : null
+            wings: player.equipped.wings ? player.equipped.wings.id : null,
+            armor: player.equipped.armor ? player.equipped.armor.id : null
         },
         isEvolved: player.isEvolved,
         stats: {
@@ -389,7 +390,7 @@ window.addEventListener('keyup', (e) => {
         if (gameState === 'PLAYING') {
             // When opening inventory away from a nest, clear staging
             if (!player.atNest) {
-                player.stagedEquipment = { arms: null, legs: null, weapon: null, wings: null };
+                player.stagedEquipment = { arms: null, legs: null, weapon: null, wings: null, armor: null };
             }
             gameState = 'INVENTORY';
         } else if (gameState === 'INVENTORY') {
@@ -430,9 +431,10 @@ function startGame(slotIndex) {
         arms: data.equipped.arms ? getItemById(data.equipped.arms) : null,
         legs: data.equipped.legs ? getItemById(data.equipped.legs) : null,
         weapon: data.equipped.weapon ? getItemById(data.equipped.weapon) : null,
-        wings: data.equipped.wings ? getItemById(data.equipped.wings) : null
+        wings: data.equipped.wings ? getItemById(data.equipped.wings) : null,
+        armor: data.equipped.armor ? getItemById(data.equipped.armor) : null
     };
-    if (data.isEvolved || player.equipped.arms || player.equipped.legs || player.equipped.weapon || player.equipped.wings) {
+    if (data.isEvolved || player.equipped.arms || player.equipped.legs || player.equipped.weapon || player.equipped.wings || player.equipped.armor) {
         player.evolve();
     }
     gameState = 'PLAYING';

--- a/js/player.js
+++ b/js/player.js
@@ -18,8 +18,9 @@ export default class Player {
         this.lastNest = null; // Last visited nest for respawn
 
         // --- UPDATED: Equipment System ---
-        this.equipped = { arms: null, legs: null, weapon: null, wings: null };
-        this.stagedEquipment = { arms: null, legs: null, weapon: null, wings: null }; // Pending changes
+        this.equipped = { arms: null, legs: null, weapon: null, wings: null, armor: null };
+        this.stagedEquipment = { arms: null, legs: null, weapon: null, wings: null, armor: null }; // Pending changes
+        this.itemSprites = {}; // Lazy-loaded item images
 
         // --- NEW: Unevolved slug sprites ---
         this.sprites = {
@@ -127,6 +128,7 @@ export default class Player {
         if (this.equipped.legs) total += this.equipped.legs.stats.Weight;
         if (this.equipped.weapon) total += this.equipped.weapon.stats.Weight;
         if (this.equipped.wings) total += this.equipped.wings.stats.Weight;
+        if (this.equipped.armor) total += this.equipped.armor.stats.Weight;
         return total;
     }
 
@@ -260,20 +262,40 @@ export default class Player {
         }
 
         if (this.equipped.weapon) {
-            context.fillStyle = '#bbb';
+            const weapon = this.equipped.weapon;
             const swordWidth = 4;
             const swordHeight = 25;
             const handX = drawX + this.width + Math.cos(armAngle) * armLength;
             const handY = drawY + this.height * 0.6 + Math.sin(armAngle) * armLength;
             context.save();
             context.translate(handX, handY);
+            let img = null;
+            if (weapon.image) {
+                img = this.itemSprites[weapon.id];
+                if (!img) {
+                    img = new Image();
+                    img.src = weapon.image;
+                    this.itemSprites[weapon.id] = img;
+                }
+            }
             if (this.slashTimer > 0) {
                 const progress = 1 - this.slashTimer / this.slashDuration;
                 const angle = progress * Math.PI;
                 context.rotate(angle);
-                context.fillRect(0, -swordWidth / 2, swordHeight, swordWidth);
+                if (img && img.complete) {
+                    context.drawImage(img, 0, -weapon.height / 2, weapon.width, weapon.height);
+                } else {
+                    context.fillStyle = '#bbb';
+                    context.fillRect(0, -swordWidth / 2, swordHeight, swordWidth);
+                }
             } else {
-                context.fillRect(-swordWidth / 2, -swordHeight, swordWidth, swordHeight);
+                if (img && img.complete) {
+                    context.rotate(-Math.PI / 2);
+                    context.drawImage(img, -weapon.height / 2, -weapon.width, weapon.height, weapon.width);
+                } else {
+                    context.fillStyle = '#bbb';
+                    context.fillRect(-swordWidth / 2, -swordHeight, swordWidth, swordHeight);
+                }
             }
             context.restore();
         }

--- a/js/room.js
+++ b/js/room.js
@@ -152,6 +152,7 @@ export default class Room {
                     player.health -= enemy.damage;
                     if (player.stopRunning) player.stopRunning();
                     enemy.hasDealtDamage = true;
+                    if (enemy.onDealDamage) enemy.onDealDamage(player);
                 }
             }
 
@@ -184,6 +185,7 @@ export default class Room {
                         player.health -= enemy.damage;
                         if (player.stopRunning) player.stopRunning();
                         enemy.hasDealtDamage = true;
+                        if (enemy.onDealDamage) enemy.onDealDamage(player);
                     }
                     enemy.mouthOpen = true;
                     enemy.mouthTimer = 20;
@@ -199,6 +201,7 @@ export default class Room {
                         player.health -= enemy.damage;
                         if (player.stopRunning) player.stopRunning();
                         enemy.hasDealtDamage = true;
+                        if (enemy.onDealDamage) enemy.onDealDamage(player);
                     }
                     enemy.mouthOpen = true;
                     enemy.mouthTimer = 20;

--- a/js/ui.js
+++ b/js/ui.js
@@ -12,6 +12,7 @@ export class InventoryUI {
 
         this.itemRects = [];
         this.slotRects = {};
+        this.images = {}; // cache for item images
     }
 
     /**
@@ -120,6 +121,13 @@ export class InventoryUI {
                 type: 'wings',
                 x: previewBoxX + (previewBoxWidth - slotSize) / 2,
                 y: previewBoxY + 10,
+                width: slotSize,
+                height: slotSize
+            },
+            armor: {
+                type: 'armor',
+                x: previewBoxX + 10,
+                y: previewBoxY + previewBoxHeight - slotSize - 10,
                 width: slotSize,
                 height: slotSize
             }
@@ -243,16 +251,29 @@ export class InventoryUI {
     }
 
     drawItemIcon(ctx, item, centerX, centerY, size) {
-        ctx.fillStyle = '#ccc';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.font = `${size}px Arial`;
-        let text = 'I';
-        if (item.type === 'arms') text = 'A';
-        else if (item.type === 'legs') text = 'L';
-        else if (item.type === 'weapon') text = 'S';
-        else if (item.type === 'wings') text = 'W';
-        ctx.fillText(text, centerX, centerY);
+        if (item.image) {
+            let img = this.images[item.image];
+            if (!img) {
+                img = new Image();
+                img.src = item.image;
+                this.images[item.image] = img;
+            }
+            if (img.complete) {
+                ctx.drawImage(img, centerX - size/2, centerY - size/2, size, size);
+            }
+        } else {
+            ctx.fillStyle = '#ccc';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.font = `${size}px Arial`;
+            let text = 'I';
+            if (item.type === 'arms') text = 'A';
+            else if (item.type === 'legs') text = 'L';
+            else if (item.type === 'weapon') text = 'S';
+            else if (item.type === 'wings') text = 'W';
+            else if (item.type === 'armor') text = 'C';
+            ctx.fillText(text, centerX, centerY);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add new armor slot to player equipment and inventory UI
- Render q-tip weapon using dedicated sprite
- Make skinks retreat briefly after damaging the player before charging back

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a122485f083289ac95806bd482f12