### PR TITLE
Add attack and look direction keybind support

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,9 @@
                     <div class="bind-row"><span>Jump</span><button id="jump-key-btn">I</button></div>
                     <div class="bind-row"><span>Inventory</span><button id="inventory-key-btn">E</button></div>
                     <div class="bind-row"><span>Interact</span><button id="interact-key-btn">O</button></div>
+                    <div class="bind-row"><span>Attack</span><button id="attack-key-btn">U</button></div>
+                    <div class="bind-row"><span>Look Up</span><button id="lookup-key-btn">W</button></div>
+                    <div class="bind-row"><span>Look Down</span><button id="lookdown-key-btn">S</button></div>
                 </div>
             </div>
             <div id="settings-visuals" class="hidden">

--- a/js/main.js
+++ b/js/main.js
@@ -24,6 +24,9 @@ const rightKeyBtn = document.getElementById('right-key-btn');
 const jumpKeyBtn = document.getElementById('jump-key-btn');
 const inventoryKeyBtn = document.getElementById('inventory-key-btn');
 const interactKeyBtn = document.getElementById('interact-key-btn');
+const attackKeyBtn = document.getElementById('attack-key-btn');
+const lookupKeyBtn = document.getElementById('lookup-key-btn');
+const lookdownKeyBtn = document.getElementById('lookdown-key-btn');
 const saveBindsBtn = document.getElementById('save-binds');
 const resetBindsBtn = document.getElementById('reset-binds');
 const backButton = document.getElementById('back-button');
@@ -497,6 +500,9 @@ function updateBindDisplay() {
     jumpKeyBtn.textContent = input.bindings.jump.toUpperCase();
     inventoryKeyBtn.textContent = input.bindings.inventory.toUpperCase();
     interactKeyBtn.textContent = input.bindings.interact.toUpperCase();
+    attackKeyBtn.textContent = input.bindings.attack.toUpperCase();
+    lookupKeyBtn.textContent = input.bindings.lookUp.toUpperCase();
+    lookdownKeyBtn.textContent = input.bindings.lookDown.toUpperCase();
 }
 
 rebindButton.addEventListener('click', () => {
@@ -529,6 +535,15 @@ inventoryKeyBtn.addEventListener('click', () => {
 });
 interactKeyBtn.addEventListener('click', () => {
     input.startRebind('interact');
+});
+attackKeyBtn.addEventListener('click', () => {
+    input.startRebind('attack');
+});
+lookupKeyBtn.addEventListener('click', () => {
+    input.startRebind('lookUp');
+});
+lookdownKeyBtn.addEventListener('click', () => {
+    input.startRebind('lookDown');
 });
 
 input.onRebindComplete = updateBindDisplay;


### PR DESCRIPTION
## Summary
- add rebind UI entries for attack and vertical look controls
- wire up attack and look direction buttons to input bindings

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b419a20748328ab799a6c26c03021