### PR TITLE
Add spider ability and refine combat mechanics

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -17,12 +17,17 @@ export class Enemy {
         this.strengths = {};
         this.weaknesses = {};
         this.damageType = 'physical';
+
+        this.slowTimer = 0;
+        this.slowFactor = 1;
     }
 
     update(room) {
+        if (this.slowTimer > 0) this.slowTimer--;
+        else this.slowFactor = 1;
         this.vy += 0.8;
-        this.x += this.vx;
-        this.y += this.vy;
+        this.x += this.vx * this.slowFactor;
+        this.y += this.vy * this.slowFactor;
         this.onGround = false;
         room.platforms.forEach(p => {
             if (this.x < p.x + p.width &&
@@ -41,6 +46,10 @@ export class Enemy {
     draw(ctx) {
         ctx.fillStyle = this.color;
         ctx.fillRect(this.x, this.y, this.width, this.height);
+        if (this.slowTimer > 0) {
+            ctx.fillStyle = 'rgba(255,255,255,0.5)';
+            ctx.fillRect(this.x, this.y, this.width, this.height);
+        }
     }
 }
 
@@ -366,6 +375,10 @@ export class LittleBrownSkink extends Enemy {
             const mouthY = this.mouth.y + (this.mouth.height - currentHeight) / 2;
             ctx.fillStyle = '#ff9acb';
             ctx.fillRect(this.mouth.x, mouthY, this.mouth.width, currentHeight);
+        }
+        if (this.slowTimer > 0) {
+            ctx.fillStyle = 'rgba(255,255,255,0.5)';
+            ctx.fillRect(this.x, this.y, this.width, this.height);
         }
     }
 }

--- a/js/input.js
+++ b/js/input.js
@@ -10,7 +10,8 @@ export default class InputHandler {
             interact: 'o',
             attack: 'u',
             lookUp: 'w',
-            lookDown: 's'
+            lookDown: 's',
+            ability: ' '
         };
         this.awaitingAction = null;
         this.onRebindComplete = null;
@@ -65,7 +66,8 @@ export default class InputHandler {
             interact: 'o',
             attack: 'u',
             lookUp: 'w',
-            lookDown: 's'
+            lookDown: 's',
+            ability: ' '
         };
         if (this.onRebindComplete) this.onRebindComplete();
     }

--- a/js/items.js
+++ b/js/items.js
@@ -26,6 +26,18 @@ export const items = {
     wings: {
         // future wing items can go here
     },
+    abilities: {
+        spittingSpiderAbdomen: {
+            id: 'spitting_spider_abdomen',
+            name: 'Spitting Spider Abdomen',
+            type: 'ability',
+            width: 20,
+            height: 20,
+            color: '#000000',
+            stats: { Weight: 30 },
+            description: 'Fires webbing that slows foes.'
+        }
+    },
     swords: {
         usedQtip: {
             id: 'used_q_tip',

--- a/js/projectiles.js
+++ b/js/projectiles.js
@@ -1,0 +1,34 @@
+export class WebProjectile {
+    constructor(x, y, dx, dy) {
+        const speed = 5;
+        this.x = x;
+        this.y = y;
+        this.vx = dx * speed;
+        this.vy = dy * speed;
+        this.radius = 5;
+        this.life = 60; // frames
+    }
+
+    update() {
+        this.x += this.vx;
+        this.y += this.vy;
+        this.life--;
+    }
+
+    draw(ctx) {
+        ctx.strokeStyle = '#ffffff';
+        ctx.beginPath();
+        ctx.moveTo(this.x - this.vx * 0.2, this.y - this.vy * 0.2);
+        ctx.lineTo(this.x, this.y);
+        ctx.stroke();
+    }
+
+    collides(enemy) {
+        return (
+            this.x > enemy.x &&
+            this.x < enemy.x + enemy.width &&
+            this.y > enemy.y &&
+            this.y < enemy.y + enemy.height
+        );
+    }
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -130,6 +130,20 @@ export class InventoryUI {
                 y: previewBoxY + previewBoxHeight - slotSize - 10,
                 width: slotSize,
                 height: slotSize
+            },
+            ability: {
+                type: 'ability',
+                x: previewBoxX + previewBoxWidth - slotSize - 10,
+                y: previewBoxY + previewBoxHeight - slotSize - 10,
+                width: slotSize,
+                height: slotSize
+            },
+            trinket: {
+                type: 'trinket',
+                x: previewBoxX - slotSize - 10,
+                y: previewBoxY + (previewBoxHeight - slotSize) / 2,
+                width: slotSize,
+                height: slotSize
             }
         };
 
@@ -261,6 +275,11 @@ export class InventoryUI {
             if (img.complete) {
                 ctx.drawImage(img, centerX - size/2, centerY - size/2, size, size);
             }
+        } else if (item.type === 'ability') {
+            ctx.fillStyle = item.color;
+            ctx.beginPath();
+            ctx.arc(centerX, centerY, size/2, 0, Math.PI * 2);
+            ctx.fill();
         } else {
             ctx.fillStyle = '#ccc';
             ctx.textAlign = 'center';
@@ -272,6 +291,7 @@ export class InventoryUI {
             else if (item.type === 'weapon') text = 'S';
             else if (item.type === 'wings') text = 'W';
             else if (item.type === 'armor') text = 'C';
+            else if (item.type === 'trinket') text = 'T';
             ctx.fillText(text, centerX, centerY);
         }
     }


### PR DESCRIPTION
## Summary
- Add ability and trinket equipment slots with inventory UI support
- Implement Spitting Spider Abdomen ability that fires slowing web projectiles
- Require sword contact for damage and create directional attack arcs
- Halve player movement speeds and add enemy slow effect visuals

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check js/enemy.js js/input.js js/items.js js/main.js js/player.js js/ui.js js/projectiles.js`


------
https://chatgpt.com/codex/tasks/task_e_689b4c209ddc83288f45cc928488f757