### PR TITLE
Add attack visuals, double jump wings, and new nest items

### DIFF
--- a/js/items.js
+++ b/js/items.js
@@ -24,7 +24,16 @@ export const items = {
         }
     },
     wings: {
-        // future wing items can go here
+        leafWings: {
+            id: 'leaf_wings',
+            name: 'Leaf Wings',
+            type: 'wings',
+            width: 30,
+            height: 20,
+            color: '#228B22',
+            stats: { Weight: 5 },
+            description: 'Lightweight wings that allow double jumping.'
+        }
     },
     abilities: {
         spittingSpiderAbdomen: {

--- a/js/levels.js
+++ b/js/levels.js
@@ -35,6 +35,8 @@ export const levelData = {
         interactables: [
             { ...items.arms.brokenArms, uid: 'broken_arms_1', respawnType: 'never', x: 600, y: 570 },
             { ...items.legs.brokenLegs, uid: 'broken_legs_1', respawnType: 'never', x: 850, y: 570 },
+            { ...items.abilities.spittingSpiderAbdomen, uid: 'spider_sa_1', respawnType: 'never', x: 930, y: 560 },
+            { ...items.wings.leafWings, uid: 'leaf_wings_1', respawnType: 'never', x: 970, y: 560 },
             // Sword near the first skink spawn
             { ...items.swords.usedQtip, uid: 'qtip_sword_1', respawnType: 'never', x: 1300, y: 560 }
         ],


### PR DESCRIPTION
## Summary
- Flash attack area red and animate arms during attacks
- Add leaf wings item granting double jump and color it when equipped
- Place spider abdomen ability and leaf wings near the nest
- Limit attack hitboxes to player quadrants

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*
- `node --check js/items.js && node --check js/levels.js && node --check js/player.js`


------
https://chatgpt.com/codex/tasks/task_e_689b5274b770832898d8b09d94c1c68b