### PR TITLE
Expand attack reach and add starter items

### DIFF
--- a/js/levels.js
+++ b/js/levels.js
@@ -37,6 +37,7 @@ export const levelData = {
             { ...items.legs.brokenLegs, uid: 'broken_legs_1', respawnType: 'never', x: 850, y: 570 },
             { ...items.abilities.spittingSpiderAbdomen, uid: 'spider_sa_1', respawnType: 'never', x: 930, y: 560 },
             { ...items.wings.leafWings, uid: 'leaf_wings_1', respawnType: 'never', x: 970, y: 560 },
+            { ...items.armor.basicShell, uid: 'basic_shell_1', respawnType: 'never', x: 1010, y: 560 },
             // Sword near the first skink spawn
             { ...items.swords.usedQtip, uid: 'qtip_sword_1', respawnType: 'never', x: 1300, y: 560 }
         ],

--- a/js/player.js
+++ b/js/player.js
@@ -456,15 +456,28 @@ export default class Player {
         let area;
         const quarterW = this.width / 4;
         const quarterH = this.height / 4;
+        const sideWidth = quarterW * 3;
+        const upDownWidth = this.width * 1.5;
+        const horizontalOffset = (upDownWidth - this.width) / 2;
         if (this.lookDirection === 'up') {
-            area = { x: this.x, y: this.y - quarterH, width: this.width, height: quarterH };
+            area = {
+                x: this.x - horizontalOffset,
+                y: this.y - quarterH,
+                width: upDownWidth,
+                height: quarterH
+            };
         } else if (this.lookDirection === 'down') {
-            area = { x: this.x, y: this.y + this.height, width: this.width, height: quarterH };
+            area = {
+                x: this.x - horizontalOffset,
+                y: this.y + this.height,
+                width: upDownWidth,
+                height: quarterH
+            };
         } else {
             if (this.facingRight) {
-                area = { x: this.x + this.width, y: this.y, width: quarterW, height: this.height };
+                area = { x: this.x + this.width, y: this.y, width: sideWidth, height: this.height };
             } else {
-                area = { x: this.x - quarterW, y: this.y, width: quarterW, height: this.height };
+                area = { x: this.x - sideWidth, y: this.y, width: sideWidth, height: this.height };
             }
         }
         const intersects = (a, b) => {


### PR DESCRIPTION
## Summary
- Extend side attacks to three times their previous reach and widen vertical attacks by 50%
- Drop basic shell armor in room 1 alongside wings and spider ability for easy testing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b55130ee083288d7d91efc2c95eae