### PR TITLE
Refine movement, attacks, and abilities

### DIFF
--- a/js/projectiles.js
+++ b/js/projectiles.js
@@ -1,11 +1,11 @@
 export class WebProjectile {
-    constructor(x, y, dx, dy, groundY) {
+    constructor(x, y, dx, dy, groundY, parentVx = 0, parentVy = 0) {
         const speed = 5;
         this.x = x;
         this.y = y;
-        this.vx = dx * speed;
-        this.vy = dy * speed;
-        this.radius = 10;
+        this.vx = dx * speed + parentVx;
+        this.vy = dy * speed + parentVy;
+        this.radius = 2.5;
         this.groundY = groundY;
         this.hitGround = false;
     }
@@ -20,6 +20,7 @@ export class WebProjectile {
     }
 
     draw(ctx) {
+        if (this.hitGround) return;
         ctx.fillStyle = '#ffffff';
         ctx.beginPath();
         ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);

--- a/js/room.js
+++ b/js/room.js
@@ -109,7 +109,6 @@ export default class Room {
 
             if (enemy.interacting && enemy.interactTarget && enemy.interactTarget !== player) {
                 enemy.hasDealtDamage = false;
-                return;
             }
 
             if (enemy.sleeping) {
@@ -273,9 +272,11 @@ export default class Room {
                 } else if (player.vx > 0 && playerPrevRight <= platform.x) {
                     player.x = platform.x - player.width;
                     player.vx = 0;
+                    if (player.stopRunning) player.stopRunning();
                 } else if (player.vx < 0 && playerPrevLeft >= platform.x + platform.width) {
                     player.x = platform.x + platform.width;
                     player.vx = 0;
+                    if (player.stopRunning) player.stopRunning();
                 }
             }
         });


### PR DESCRIPTION
## Summary
- Stop player running when colliding with room boundaries or platforms
- Limit side attacks to the player's height and add wing flap animation on double jump
- Shrink web projectiles, add player's momentum, and keep skinks solid during interactions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b6082f0308328b4284d5452f2320f