### PR TITLE
Make meat collectible and add skink eating behavior

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -102,6 +102,11 @@ export class LittleBrownSkink extends Enemy {
         // Post-hit behavior
         this.afterHitState = null; // 'retreat' or 'charge'
         this.afterHitTimer = 0;
+
+        // Meat eating behaviour
+        this.targetMeat = null;
+        this.eating = false;
+        this.eatingTimer = 0;
     }
 
     stun(duration) {
@@ -162,6 +167,35 @@ export class LittleBrownSkink extends Enemy {
     }
 
     update(room, player) {
+        if (this.eating) {
+            this.vx = 0;
+            this.mouthOpen = false;
+            if (this.eatingTimer > 0) {
+                this.eatingTimer--;
+                if (this.eatingTimer === 0) {
+                    this.eating = false;
+                    this.health = Math.min(this.health + 5, 20);
+                }
+            }
+            super.update(room);
+            return;
+        }
+
+        if (this.targetMeat) {
+            const dx = this.targetMeat.x - this.x;
+            this.direction = dx > 0 ? 1 : -1;
+            this.vx = this.baseSpeed * this.direction;
+            if (Math.abs(dx) < 5) {
+                this.x = this.targetMeat.x;
+                this.targetMeat = null;
+                this.eating = true;
+                this.eatingTimer = 120;
+                this.vx = 0;
+            }
+            super.update(room);
+            return;
+        }
+
         if (this.sleepTimer > 0) {
             this.sleepTimer--;
             if (this.sleepTimer === 0) {
@@ -356,12 +390,16 @@ export class LittleBrownSkink extends Enemy {
         ctx.arc(this.x + this.width / 2, this.y + this.height / 2, this.scanRange, 0, Math.PI * 2);
         ctx.fill();
 
-        if (this.sleeping) {
+        if (this.sleeping || this.eating) {
             ctx.fillStyle = this.color;
             ctx.fillRect(this.x, this.y + this.height / 2, this.width, this.height / 2);
             const headX = this.direction === 1 ? this.x + this.width : this.x - this.headWidth;
             ctx.fillStyle = '#2ecc71';
             ctx.fillRect(headX, this.y + this.height / 2, this.headWidth, this.headHeight);
+            if (this.eating) {
+                ctx.fillStyle = '#ff9acb';
+                ctx.fillRect(headX + this.headWidth * 0.3, this.y + this.height / 2 + this.headHeight * 0.4, this.headWidth * 0.4, this.headHeight * 0.2);
+            }
             return;
         }
 

--- a/js/player.js
+++ b/js/player.js
@@ -535,12 +535,14 @@ export default class Player {
                     if (room && room.powerups) {
                         const drops = 1 + Math.floor(Math.random() * 2);
                         for (let d = 0; d < drops; d++) {
+                            const size = 20;
                             room.powerups.push({
                                 type: 'meat',
-                                x: enemy.x + enemy.width / 2 - 10 + d * 15,
-                                y: enemy.y + enemy.height - 10,
-                                width: 20,
-                                height: 20
+                                x: enemy.x + enemy.width / 2 - size / 2 + d * 15,
+                                y: enemy.y + enemy.height - size,
+                                width: size,
+                                height: size,
+                                timer: 0
                             });
                         }
                     }

--- a/js/room.js
+++ b/js/room.js
@@ -208,14 +208,6 @@ export default class Room {
                     player.vy = 0;
                     player.y = enemy.y + enemy.height;
                 } else if (!enemy.sleeping && playerPrevRight <= enemyPrevLeft && player.x + player.width > enemy.x) {
-                    if (!enemy.hasDealtDamage) {
-                        player.applyDamage(enemy.damage, enemy.damageType);
-                        if (player.stopRunning) player.stopRunning();
-                        enemy.hasDealtDamage = true;
-                        if (enemy.onDealDamage) enemy.onDealDamage(player);
-                    }
-                    enemy.mouthOpen = true;
-                    enemy.mouthTimer = 20;
                     if (player.vx > 0) {
                         player.x = enemy.x - player.width;
                         player.vx = 0;
@@ -224,14 +216,6 @@ export default class Room {
                         enemy.vx = 0;
                     }
                 } else if (!enemy.sleeping && playerPrevLeft >= enemyPrevRight && player.x < enemy.x + enemy.width) {
-                    if (!enemy.hasDealtDamage) {
-                        player.applyDamage(enemy.damage, enemy.damageType);
-                        if (player.stopRunning) player.stopRunning();
-                        enemy.hasDealtDamage = true;
-                        if (enemy.onDealDamage) enemy.onDealDamage(player);
-                    }
-                    enemy.mouthOpen = true;
-                    enemy.mouthTimer = 20;
                     if (player.vx < 0) {
                         player.x = enemy.x + enemy.width;
                         player.vx = 0;
@@ -248,6 +232,7 @@ export default class Room {
         });
 
         this.handleSkinkInteractions();
+        this.handleMeat();
     }
 
     handleSkinkInteractions() {
@@ -264,6 +249,30 @@ export default class Room {
                         const sleeper = Math.random() < 0.5 ? a : b;
                         a.startInteraction(b, sleeper === a);
                         b.startInteraction(a, sleeper === b);
+                    }
+                }
+            }
+        }
+    }
+
+    handleMeat() {
+        for (let i = 0; i < this.powerups.length; i++) {
+            const p = this.powerups[i];
+            if (p.type === 'meat') {
+                p.timer = (p.timer || 0) + 1;
+                if (p.timer > 180) {
+                    let nearest = null;
+                    let dist = Infinity;
+                    this.enemies.forEach(e => {
+                        if (e instanceof LittleBrownSkink && !e.eating && !e.targetMeat) {
+                            const d = Math.abs((e.x + e.width / 2) - (p.x + p.width / 2));
+                            if (d < dist) { dist = d; nearest = e; }
+                        }
+                    });
+                    if (nearest) {
+                        nearest.targetMeat = { x: p.x, y: p.y, width: p.width, height: p.height };
+                        this.powerups.splice(i, 1);
+                        i--;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Ensure meat drops spawn on top of the ground and track a timer
- Prevent skinks from damaging players with their bodies; only head or mouth attacks hurt
- Allow skinks to collect leftover meat, lie down to eat for 2 seconds, and heal

## Testing
- `node --check js/player.js`
- `node --check js/enemy.js`
- `node --check js/room.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b6c4d76548328bbab8eb7a7cd9850