### PR TITLE
fix duplicate headX declaration in draw()

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -475,7 +475,6 @@ export class LittleBrownSkink extends Enemy {
         });
 
         // Head
-        const headX = this.headDirection === 1 ? this.x + this.width : this.x - this.headWidth;
         ctx.fillStyle = '#2ecc71';
         ctx.fillRect(headX, this.y + this.height * 0.1, this.headWidth, this.headHeight);
 


### PR DESCRIPTION
## Summary
- avoid redeclaring `headX` in `draw` so script parses correctly

## Testing
- `node --check js/enemy.js`


------
https://chatgpt.com/codex/tasks/task_e_68a217bbd95483288dd53821c205fe96