### PR TITLE
Allow weapon swapping outside nests and restore skink attacks

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -314,7 +314,7 @@ export class LittleBrownSkink extends Enemy {
             const facingAngle = this.headDirection === 1 ? 0 : Math.PI;
             angleDiff = ((angleToPlayer - facingAngle + Math.PI) % (Math.PI * 2)) - Math.PI;
         }
-        const canSee = dist < this.scanRange && Math.abs(angleDiff) <= this.fov / 2 && this.hasLineOfSight(player, room);
+        const canSee = dist < this.scanRange && this.hasLineOfSight(player, room);
 
         if (!this.aggro && canSee) {
             this.aggro = true;
@@ -400,6 +400,7 @@ export class LittleBrownSkink extends Enemy {
             this.mouthTimer--;
             if (this.mouthTimer === 0) {
                 this.mouthOpen = false;
+                this.hasDealtDamage = false;
             }
         } else if (this.aggro && this.wakeDelay === 0 && this.postStunDelay === 0) {
             this.attack(player);

--- a/js/player.js
+++ b/js/player.js
@@ -99,8 +99,8 @@ export default class Player {
      * Moves a selected item into the staging area, ready for shedding.
      */
     stageItem(item) {
-        if (item.type === 'weapon' && !(this.equipped.arms || this.stagedEquipment.arms)) {
-            console.log('Need arms to equip a weapon.');
+        if (item.type === 'weapon') {
+            this.equipWeapon(item);
             return;
         }
         if (item.type in this.stagedEquipment) {
@@ -117,6 +117,40 @@ export default class Player {
             this.stagedEquipment[itemType] = null;
             console.log(`Unstaged ${itemType}.`);
         }
+    }
+
+    equipWeapon(item) {
+        if (!(this.equipped.arms || this.stagedEquipment.arms)) {
+            console.log('Need arms to equip a weapon.');
+            return;
+        }
+        this.equipped.weapon = item;
+        this.stagedEquipment.weapon = null;
+        console.log(`Equipped ${item.name}`);
+    }
+
+    unequipWeapon() {
+        if (this.equipped.weapon) {
+            console.log(`Unequipped ${this.equipped.weapon.name}`);
+            this.equipped.weapon = null;
+        }
+    }
+
+    removeEquipment(type) {
+        if (!this.equipped[type]) return;
+        if (type === 'arms' && this.equipped.weapon) {
+            this.unequipWeapon();
+        }
+        if (type === 'legs') {
+            const oldHeight = this.getLegHeight();
+            this.equipped.legs = null;
+            const newHeight = this.getLegHeight();
+            this.y -= (newHeight - oldHeight);
+            this.vy = 0;
+        } else {
+            this.equipped[type] = null;
+        }
+        console.log(`Removed ${type}.`);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Let skinks reacquire targets and reset bite damage so they can pause, charge and retreat properly
- Allow the sword to be equipped or unequipped anywhere and permit limb removal away from nests
- Update inventory UI for immediate weapon swapping and limb removal slots

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/enemy.js js/player.js js/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68a21d6670588328889823b9fb31ca84