### PR TITLE
Fix skink behavior and inventory item interaction

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -322,8 +322,9 @@ export class LittleBrownSkink extends Enemy {
         } else if (this.aggro && !canSee) {
             this.aggro = false;
             this.speed = this.baseSpeed;
-            this.searchTimer = 60;
-            this.searchFlipTimer = 30;
+            // keep moving in the same direction without turning to search
+            this.searchTimer = 0;
+            this.searchFlipTimer = 0;
             this.headDirection = this.direction;
         }
 

--- a/js/room.js
+++ b/js/room.js
@@ -164,6 +164,8 @@ export default class Room {
                 enemy.vx = 0;
                 player.applyDamage(enemy.damage, enemy.damageType);
                 if (player.stopRunning) player.stopRunning();
+                enemy.hasDealtDamage = true;
+                if (enemy.onDealDamage) enemy.onDealDamage(player);
             }
 
             // Mouth collision when attacking


### PR DESCRIPTION
## Summary
- Ensure skinks retreat and stop turning when player is lost
- Add damage feedback when skinks bump into player
- Replace full-screen item popup with compact equip/stats menu

## Testing
- `node --check js/ui.js`
- `node --check js/enemy.js js/room.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a225fcfab88328b986d7539c18a7e2