### PR TITLE
Extend skink legs and enable leg damage

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -57,7 +57,7 @@ export class LittleBrownSkink extends Enemy {
     constructor(x, y, id, respawnType = 'room') {
         // Enemy size relative to the unevolved player
         const width = 40 * 2.5;      // Slightly shorter than before
-        const height = 20 * 0.5;     // Half the player height
+        const height = 20 * 1.5;     // Taller with extended legs
 
         super(x, y, width, height, '#ff69b4', id, respawnType);
         this.health = 20;
@@ -443,7 +443,7 @@ export class LittleBrownSkink extends Enemy {
         ctx.fillStyle = this.color;
         ctx.fillRect(this.x, this.y, this.width, this.height);
 
-        const legLen = this.height * 0.6;
+        const legLen = this.height * 0.8;
         const legWidth = 4;
         const angle = Math.sin(this.walkCycle) * 0.4 * this.direction;
 

--- a/js/levels.js
+++ b/js/levels.js
@@ -53,8 +53,8 @@ export const levelData = {
             }
         ],
         enemies: [
-            { id: 'skink_1', type: "little_brown_skink", x: 1300, y: 570, respawnType: 'room' },
-            { id: 'skink_2', type: "little_brown_skink", x: 1800, y: 570, respawnType: 'room' }
+            { id: 'skink_1', type: "little_brown_skink", x: 1300, y: 550, respawnType: 'room' },
+            { id: 'skink_2', type: "little_brown_skink", x: 1800, y: 550, respawnType: 'room' }
         ],
     },
 };

--- a/js/room.js
+++ b/js/room.js
@@ -153,7 +153,7 @@ export default class Room {
                 player.x < enemy.head.x + enemy.head.width &&
                 player.x + player.width > enemy.head.x &&
                 player.y < enemy.head.y + enemy.head.height &&
-                player.y + player.height > enemy.head.y) {
+                player.y + player.height + player.getLegHeight() > enemy.head.y) {
                 isColliding = true;
                 // Position the skink so its head stays against the player
                 if (enemy.direction === 1) {
@@ -175,7 +175,7 @@ export default class Room {
                     player.x < m.x + m.width &&
                     player.x + player.width > m.x &&
                     player.y < m.y + m.height &&
-                    player.y + player.height > m.y
+                    player.y + player.height + player.getLegHeight() > m.y
                 ) {
                     isColliding = true;
                     player.applyDamage(enemy.damage, enemy.damageType);


### PR DESCRIPTION
## Summary
- make skink taller by extending leg length and adjusting spawn height
- allow skink head and mouth collisions to damage player's legs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a22af4e52c83289660ddedd82fa8b8