### PR TITLE
Add deep second room accessed via hidden hole

### DIFF
--- a/js/levels.js
+++ b/js/levels.js
@@ -5,6 +5,7 @@ import { items } from './items.js';
 const CANVAS_WIDTH = 800;
 const CANVAS_HEIGHT = 600;
 const ROOM1_WIDTH = 2600;
+const ROOM2_HEIGHT = 1800;
 
 export const levelData = {
     1: {
@@ -15,7 +16,8 @@ export const levelData = {
         backgroundColor: '#34495e',
         playerStart: { x: 30, y: 540 },
         platforms: [
-            { x: 0, y: 580, width: ROOM1_WIDTH, height: 20, color: '#7f8c8d' },
+            { x: 0, y: 580, width: 1200, height: 20, color: '#7f8c8d' },
+            { x: 1300, y: 580, width: ROOM1_WIDTH - 1300, height: 20, color: '#7f8c8d' },
             { x: 0, y: 0, width: ROOM1_WIDTH, height: 20, color: '#7f8c8d' },
             // Small stone to test jumping (scaled to 60% height)
             { x: 1080, y: 565, width: 40, height: 15, color: '#95a5a6' },
@@ -28,6 +30,7 @@ export const levelData = {
         walls: [
             { x: ROOM1_WIDTH - 10, y: 0, width: 10, height: CANVAS_HEIGHT, color: '#27ae60', targetRoom: 1 },
             { x: 0, y: 0, width: 10, height: CANVAS_HEIGHT, color: '#7f8c8d', targetRoom: null },
+            { x: 1200, y: 580, width: 100, height: 20, color: '#000000', targetRoom: 2 },
         ],
         powerups: [
             { id: 'power_goop_1', x: 1000, y: 570, width: 50, height: 10, color: '#2ecc71', type: 'evolution_power', respawnType: 'never' }
@@ -56,5 +59,29 @@ export const levelData = {
             { id: 'skink_1', type: "little_brown_skink", x: 1300, y: 550, respawnType: 'room' },
             { id: 'skink_2', type: "little_brown_skink", x: 1800, y: 550, respawnType: 'room' }
         ],
+    },
+    2: {
+        id: 2,
+        name: "Deep Drop",
+        width: CANVAS_WIDTH,
+        height: ROOM2_HEIGHT,
+        backgroundColor: '#1a1a1a',
+        playerStart: { x: 50, y: 0 },
+        platforms: [
+            { x: 0, y: 100, width: 150, height: 20, color: '#7f8c8d' },
+            { x: 50, y: 200, width: 150, height: 20, color: '#7f8c8d' },
+            { x: 100, y: 300, width: 150, height: 20, color: '#7f8c8d' },
+            { x: 150, y: 400, width: 150, height: 20, color: '#7f8c8d' },
+            { x: 200, y: 500, width: 150, height: 20, color: '#7f8c8d' },
+            { x: 0, y: ROOM2_HEIGHT - 20, width: CANVAS_WIDTH, height: 20, color: '#7f8c8d' },
+        ],
+        walls: [
+            { x: 0, y: 0, width: 10, height: ROOM2_HEIGHT, color: '#7f8c8d', targetRoom: null },
+            { x: CANVAS_WIDTH - 10, y: 0, width: 10, height: ROOM2_HEIGHT, color: '#7f8c8d', targetRoom: null },
+        ],
+        powerups: [],
+        interactables: [],
+        nests: [],
+        enemies: [],
     },
 };


### PR DESCRIPTION
## Summary
- Cut a hole after the second rock pile that drops the player into room 2
- Introduce new vertically deep room with left-side stair platforms
- Define teleport from room 1 into the new drop room

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a49f100e108328ba9ad1016f38c5d3