### PR TITLE
Fix camera height and patch first room floor

### DIFF
--- a/js/levels.js
+++ b/js/levels.js
@@ -17,6 +17,8 @@ export const levelData = {
         playerStart: { x: 30, y: 540 },
         platforms: [
             { x: 0, y: 580, width: 1200, height: 20, color: '#7f8c8d' },
+            // Fill the gap after the initial rock steps
+            { x: 1200, y: 580, width: 100, height: 20, color: '#7f8c8d' },
             { x: 1300, y: 580, width: ROOM1_WIDTH - 1300, height: 20, color: '#7f8c8d' },
             { x: 0, y: 0, width: ROOM1_WIDTH, height: 20, color: '#7f8c8d' },
             // Small stone to test jumping (scaled to 60% height)

--- a/js/main.js
+++ b/js/main.js
@@ -74,11 +74,9 @@ const camera = {
     x: 0, y: 0, width: 0, height: 0,
     update: function(player, room) {
         this.x = player.x + player.width / 2 - this.width / 2;
-        this.y = player.y + player.height / 2 - this.height / 2;
-        if (this.x < 0) this.x = 0;
-        if (this.y < 0) this.y = 0;
-        if (this.x > room.width - this.width) this.x = room.width - this.width;
-        if (this.y > room.height - this.height) this.y = room.height - this.height;
+        this.x = Math.max(0, Math.min(this.x, room.width - this.width));
+        // Keep the camera vertically fixed to avoid showing space above the level
+        this.y = 0;
     }
 };
 


### PR DESCRIPTION
## Summary
- Keep camera vertically fixed so the first room isn't offset up the screen
- Fill the gap after the initial rock stairs in the first room

## Testing
- `node --check js/main.js js/levels.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a6d645608328b6b07540d0e210c2