### PR TITLE
Fix transition hole between rooms 1 and 2

### DIFF
--- a/js/levels.js
+++ b/js/levels.js
@@ -19,7 +19,9 @@ export const levelData = {
             { x: 0, y: 580, width: 1200, height: 20, color: '#7f8c8d' },
             // Fill the gap after the initial rock steps
             { x: 1200, y: 580, width: 100, height: 20, color: '#7f8c8d' },
-            { x: 1300, y: 580, width: ROOM1_WIDTH - 1300, height: 20, color: '#7f8c8d' },
+            // Split the long floor segment to create a hole that leads to room 2
+            { x: 1300, y: 580, width: 800, height: 20, color: '#7f8c8d' },
+            { x: 2200, y: 580, width: ROOM1_WIDTH - 2200, height: 20, color: '#7f8c8d' },
             { x: 0, y: 0, width: ROOM1_WIDTH, height: 20, color: '#7f8c8d' },
             // Small stone to test jumping (scaled to 60% height)
             { x: 1080, y: 565, width: 40, height: 15, color: '#95a5a6' },
@@ -32,7 +34,8 @@ export const levelData = {
         walls: [
             { x: ROOM1_WIDTH - 10, y: 0, width: 10, height: CANVAS_HEIGHT, color: '#27ae60', targetRoom: 1 },
             { x: 0, y: 0, width: 10, height: CANVAS_HEIGHT, color: '#7f8c8d', targetRoom: null },
-            { x: 2100, y: 580, width: 100, height: 20, color: '#000000', targetRoom: 2 },
+            // Invisible trigger at the bottom of the hole to change rooms
+            { x: 2100, y: 580, width: 100, height: 20, color: 'rgba(0,0,0,0)', targetRoom: 2 },
         ],
         powerups: [
             { id: 'power_goop_1', x: 1000, y: 570, width: 50, height: 10, color: '#2ecc71', type: 'evolution_power', respawnType: 'never' }


### PR DESCRIPTION
## Summary
- carve out a gap in room 1's floor so the player can fall through
- add invisible trigger to send player to room 2

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ab3b665483288d5ed7d1acd1e4ed