### PR TITLE
Remove gravity and enhance skink visuals

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -42,7 +42,8 @@ export default class Player {
         this.evolvedWidth = 25; this.evolvedHeight = 50;
         this.baseSpeed = 1.5;
         this.baseJumpPower = 0;
-        this.baseWeight = 0.8; // Gravity constant
+        // No gravity in the drainage pipe
+        this.baseWeight = 0;
         this.bodyWeightMg = 500; // Weight of the slug in mg
         const jumpHeight = this.evolvedHeight / 2;
         this.jumpVelocityUnit = -Math.sqrt(2 * this.baseWeight * jumpHeight);
@@ -469,7 +470,7 @@ export default class Player {
         }
         this.wasJumpPressed = jumpKeysArePressed;
 
-        this.vy += this.baseWeight;
+        // Without gravity, vertical velocity persists until stopped by collisions
         this.y += this.vy;
         this.onGround = false;
 

--- a/style.css
+++ b/style.css
@@ -21,7 +21,7 @@ html, body {
     top: 0;
     left: 0;
     display: none; /* Hidden by default */
-    background-color: #000;
+    background: radial-gradient(circle at center, #666 0%, #333 60%, #111 100%);
     z-index: 0;
 }
 


### PR DESCRIPTION
## Summary
- Disable gravity on player movement
- Prevent skinks from crossing level blocks and improve their look with natural colors and a tail
- Add a radial gradient background to mimic a drainage pipe

## Testing
- `node --check js/player.js js/enemy.js`

------
https://chatgpt.com/codex/tasks/task_e_68ab048ec64883289b70cb697aa98d34