### PR TITLE
Restore gravity for movement and animations

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -26,6 +26,7 @@ export class Enemy {
         if (this.slowTimer > 0) this.slowTimer--;
         else this.slowFactor = 1;
 
+        this.vy += 0.8;
         const moveX = this.vx * this.slowFactor;
         const moveY = this.vy * this.slowFactor;
 

--- a/js/player.js
+++ b/js/player.js
@@ -42,8 +42,7 @@ export default class Player {
         this.evolvedWidth = 25; this.evolvedHeight = 50;
         this.baseSpeed = 1.5;
         this.baseJumpPower = 0;
-        // No gravity in the drainage pipe
-        this.baseWeight = 0;
+        this.baseWeight = 0.8; // Gravity constant
         this.bodyWeightMg = 500; // Weight of the slug in mg
         const jumpHeight = this.evolvedHeight / 2;
         this.jumpVelocityUnit = -Math.sqrt(2 * this.baseWeight * jumpHeight);
@@ -470,7 +469,7 @@ export default class Player {
         }
         this.wasJumpPressed = jumpKeysArePressed;
 
-        // Without gravity, vertical velocity persists until stopped by collisions
+        this.vy += this.baseWeight;
         this.y += this.vy;
         this.onGround = false;
 


### PR DESCRIPTION
## Summary
- Re-enable gravity for enemies so they stay grounded and animate properly
- Restore player gravity constant and apply it during updates to allow jumping and walking animations

## Testing
- `node --check js/enemy.js js/player.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab0a454cb08328bd130323294fc9f4